### PR TITLE
move 404 into router

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,6 @@ router(function() {
         $body = json_in();
         render(201, json_out($body));
     });
-
-    // route not found
-    throw new \Error("Not Found", 404);
 });
 ```
 ## Requirements

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ]
   },
   "require-dev": {
-    "phpunit/phpunit": "9.5.20"
+    "phpunit/phpunit": "9.5.21"
   },
   "scripts": {
     "test": "./vendor/bin/phpunit",

--- a/src/router.php
+++ b/src/router.php
@@ -86,6 +86,8 @@ function router(callable $routes)
 
     try {
        call_user_func($routes);
+       // throw when not routes can be found
+       throw. new \Error("Not Found", 404);
     } catch (Exception $e) {
         error_log($e->getMessage());
         error_log($e->getTraceAsString());

--- a/src/router.php
+++ b/src/router.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__."/stop.php";
+require_once __DIR__ . "/stop.php";
 
 /** HTTP methods */
 const GET = 'GET';
@@ -37,7 +37,7 @@ function url_path(string $path): bool
     } elseif (!empty($path) && $path[0] === '/') {
         $path = substr($path, 1);
     }
-    
+
     return $path === $_GET['url'];
 }
 
@@ -62,12 +62,12 @@ function url_path_params(string $path): bool
     if ($pos !== false) {
         // starts with $path
         if (substr($path, 0, $pos) === substr($_GET['url'], 0, $pos)) {
-                foreach ($query_string_parts as $part => $query_string_part) {
-                    if ($path_parts[$part][0] === ':') {
-                        $_GET[$path_parts[$part]] = $query_string_part;
-                    }
+            foreach ($query_string_parts as $part => $query_string_part) {
+                if ($path_parts[$part][0] === ':') {
+                    $_GET[$path_parts[$part]] = $query_string_part;
                 }
-                return true;
+            }
+            return true;
         }
     }
 
@@ -85,9 +85,15 @@ function router(callable $routes)
     error_reporting(E_ALL);
 
     try {
-       call_user_func($routes);
-       // throw when not routes can be found
-       throw new \Error("Not Found", 404);
+        call_user_func($routes);
+
+        if (isset($GLOBALS['TEENSYPHP_STOP_CODE'])) {
+            // for testing purposes, do not throw error when stop() is called
+            return;
+        }
+
+        // throw when not routes can be found
+        throw new \Error("Not Found", 404);
     } catch (Exception $e) {
         error_log($e->getMessage());
         error_log($e->getTraceAsString());

--- a/src/router.php
+++ b/src/router.php
@@ -87,7 +87,7 @@ function router(callable $routes)
     try {
        call_user_func($routes);
        // throw when not routes can be found
-       throw. new \Error("Not Found", 404);
+       throw new \Error("Not Found", 404);
     } catch (Exception $e) {
         error_log($e->getMessage());
         error_log($e->getTraceAsString());

--- a/src/stop.php
+++ b/src/stop.php
@@ -1,10 +1,14 @@
 <?php
+
 /**
  * Exits execution. If testing is running it returns the number instead
  */
-function stop($code = 0) {
-    if (! defined('PHPUNIT_COMPOSER_INSTALL') && ! defined('__PHPUNIT_PHAR__')) {
-       exit($code);
+function stop($code = 0)
+{
+    $GLOBALS["TEENSYPHP_STOP_CODE"] = $code;
+
+    if (!defined('PHPUNIT_COMPOSER_INSTALL') && !defined('__PHPUNIT_PHAR__')) {
+        exit($code);
     }
 
     return $code;

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 use PHPUnit\Framework\TestCase;
 
 
@@ -44,43 +45,58 @@ class RouterTest extends TestCase
 
     public function test_template()
     {
-        $actual = template(__DIR__.'/_data/template.php', ['test' => 'hello']);
+        $actual = template(__DIR__ . '/_data/template.php', ['test' => 'hello']);
         $expected = '<h1>hello</h1>';
         $this->assertEquals($expected, $actual);
     }
 
     public function test_route()
     {
-        $this->assertEmpty(route(false, false, function() {$_GET['route_test_1'] = 1;}));
+        $this->assertEmpty(route(false, false, function () {
+            $_GET['route_test_1'] = 1;
+        }));
         $this->assertArrayNotHasKey('route_test_1', $_GET);
 
-        $this->assertEmpty(route(true, false, function() {$_GET['route_test_2'] = 1;}));
+        $this->assertEmpty(route(true, false, function () {
+            $_GET['route_test_2'] = 1;
+        }));
         $this->assertArrayNotHasKey('route_test_2', $_GET);
 
-        $this->assertEmpty(route(false, true, function() {$_GET['route_test_3'] = 1;}));
+        $this->assertEmpty(route(false, true, function () {
+            $_GET['route_test_3'] = 1;
+        }));
         $this->assertArrayNotHasKey('route_test_3', $_GET);
 
 
-        $this->assertEmpty(route(true, true, function() {$_GET['route_test_4'] = 1;}));
+        $this->assertEmpty(route(true, true, function () {
+            $_GET['route_test_4'] = 1;
+        }));
         $this->assertArrayHasKey('route_test_4', $_GET);
     }
 
     public function test_router()
     {
-        router(function () { $_GET['router_1'] = 1; });
-        $this->assertArrayHasKey('router_1', $_GET);
+        router(function () {
+            stop();
+        });
+
+        $this->assertArrayHasKey('TEENSYPHP_STOP_CODE', $GLOBALS);
     }
 
     public function test_router_exception()
     {
-        router(function () { throw new Exception("foo", 500); });
+        router(function () {
+            throw new Exception("foo", 500);
+        });
         $this->expectOutputString('{"error":"foo"}');
         $this->assertEquals(500, http_response_code());
     }
 
     public function test_router_error()
     {
-        router(function () { throw new Error("foo", 400); });
+        router(function () {
+            throw new Error("foo", 400);
+        });
         $this->expectOutputString('{"error":"foo"}');
         $this->assertEquals(400, http_response_code());
     }


### PR DESCRIPTION
this change removes the need to throw a 404 error at the end of the router

### Before 
```php
router(function() {
    route(method(GET), url_path("/"), fn () => render(200, json_out(['status' => 'up'])));

    // route not found
    throw new \Error("Not Found", 404);
});
```
### After

```php
router(function() {
    route(method(GET), url_path("/"), fn () => render(200, json_out(['status' => 'up'])));
});
```