### PR TITLE
fix Database:instance()

### DIFF
--- a/src/Utility/Database.php
+++ b/src/Utility/Database.php
@@ -24,7 +24,7 @@ class Database
 
     public static function instance(): Database
     {
-        if (self::$instance === null) {
+        if (isset(self::$instance) === false) {
             self::$instance = new Database();
         }
         return self::$instance;


### PR DESCRIPTION
this fixes error 
```
Uncaught Error: Typed static property TeensyPHP\Utility\Database::$instance must not be accessed before initialization in /Users/danielsamson/Herd/teensy-blog/vendor/daniel-samson/teensyphp/src/Utility/Database.php on line 27
```