### PR TITLE
fix return value from crud operations

### DIFF
--- a/src/Traits/Crud.php
+++ b/src/Traits/Crud.php
@@ -27,7 +27,7 @@ trait Crud
             TeensyPHPException::throwNotFound();
         }
 
-        $records = $statement->fetchAll();
+        $records = $statement->fetchAll(\PDO::FETCH_ASSOC);
 
         if (count($records) !== 1) {
             TeensyPHPException::throwNotFound();
@@ -51,7 +51,7 @@ trait Crud
             TeensyPHPException::throwNotFound();
         }
 
-        $records = $statement->fetchAll();
+        $records = $statement->fetchAll(\PDO::FETCH_ASSOC);
 
         return array_map(function ($record) {
             return self::make($record);


### PR DESCRIPTION
fixes the return values from Crud::findX() so that it does return both the index and the column names.